### PR TITLE
Allowing collection serialization for http requests.

### DIFF
--- a/rest-client/src/main/groovy/com/motycka/test/rest/RestClient.groovy
+++ b/rest-client/src/main/groovy/com/motycka/test/rest/RestClient.groovy
@@ -145,7 +145,7 @@ class RestClient {
     private static typeConversion(object) {
         if (object instanceof JsonBody) {
             object.asJsonString()
-        } else if (object instanceof Map) {
+        } else if (object instanceof Map || object instanceof Collection) {
             JsonOutput.toJson(object)
         } else {
             object


### PR DESCRIPTION
Máme v CA backendech endpointy, které jako body akceptují JSON z kolekcí (třeba List<String> apod.) a potřebujeme ho testovat. Kod vypadá asi takto:

`TestableResponse<Map> getProjectsByKeys(List projectKeys) {
  post("$prefix/project/get-by-keys", projectKeys)
}`

V současné době nám to hází chybu:

`java.lang.IllegalArgumentException: Unknown multipart source type
	at com.motycka.test.rest.RestClient.sendMultipart_closure1(RestClient.groovy:102)
	at groovy.lang.Closure.call(Closure.java:405)
	at groovy.lang.Closure.call(Closure.java:421)
	at com.motycka.test.rest.RestClient.sendMultipart(RestClient.groovy:93)
	at com.motycka.test.rest.RestClient.post(RestClient.groovy:51)
	at cz.clevermaps.assets.project.ProjectApi$3$2.getProjectsByKeys(ProjectApi.groovy:360)
	at cz.clevermaps.assets.project.project.ProjectSpec.POST /project/get-by-keys(ProjectSpec.groovy:315)`

Je možné, že bude ještě třeba nějaká úprava RestClient třídy, třeba přidání další post metody pro body typu Collection, ale na to se zatím necítím příliš kovaný v Groovy.